### PR TITLE
Add possibility to set email with unique=True from settings.py

### DIFF
--- a/emailconfirmation/models.py
+++ b/emailconfirmation/models.py
@@ -14,10 +14,17 @@ from django.contrib.auth.models import User
 
 from emailconfirmation.signals import email_confirmed, email_confirmation_sent
 
+# django 1.4 compatibility
 try:
     from django.utils.timezone import now
 except ImportError:
     now = datetime.datetime.now
+
+# For those who want the emails in the database to be unique they can specify EMAIL_UNIQUE = True in their settings.py
+try:
+    UNIQUE_EMAIL = settings.EMAIL_UNIQUE
+except:
+    UNIQUE_EMAIL = False
 
 # this code based in-part on django-registration
 
@@ -50,7 +57,7 @@ class EmailAddressManager(models.Manager):
 class EmailAddress(models.Model):
     
     user = models.ForeignKey(User)
-    email = models.EmailField()
+    email = models.EmailField(unique=UNIQUE_EMAIL)
     verified = models.BooleanField(default=False)
     primary = models.BooleanField(default=False)
     
@@ -75,10 +82,10 @@ class EmailAddress(models.Model):
     class Meta:
         verbose_name = _("email address")
         verbose_name_plural = _("email addresses")
-        unique_together = (
-            ("user", "email"),
-        )
-
+        if not UNIQUE_EMAIL:
+            unique_together = (
+                ("user", "email"),
+            )
 
 class EmailConfirmationManager(models.Manager):
     


### PR DESCRIPTION
I needed to add this possibility to the current code, I hope this might help somebody else.

If the setting is not specified it defaults to False.
If the settings is specified as True the email field is unique and the piece of code "unique_together" is not executed as not needed.

Fed.
